### PR TITLE
Get path for jq and yabai from config

### DIFF
--- a/bin/yabai-get-stack-idx
+++ b/bin/yabai-get-stack-idx
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-/usr/local/bin/yabai -m query --windows \
-        | /usr/local/bin/jq --raw-output --compact-output --monochrome-output  'map({"\(.id)": .["stack-index"]}) | reduce .[] as $item ({}; . + $item)'
+"$1" -m query --windows \
+        | "$2" --raw-output --compact-output --monochrome-output  'map({"\(.id)": .["stack-index"]}) | reduce .[] as $item ({}; . + $item)'
 

--- a/stackline/query.lua
+++ b/stackline/query.lua
@@ -14,7 +14,7 @@ function Query:getWinStackIdxs(onSuccess) -- {{{
         else -- try again
             hs.timer.doAfter(1, function() self:getWinStackIdxs() end)
         end
-    end, {c.paths.getStackIdxs}):start()
+    end, {c.paths.getStackIdxs, c.paths.yabai, c.paths.jq}):start()
 end -- }}}
 
 function getStackedWinIds(byStack)  -- {{{


### PR DESCRIPTION
Confirmed that stackline uses the path to jq and yabai set in the stackline config.