### PR TITLE
bugfix: pass onSuccess argument to retry of getWinStackIdxs

### DIFF
--- a/stackline/query.lua
+++ b/stackline/query.lua
@@ -12,7 +12,7 @@ function Query:getWinStackIdxs(onSuccess) -- {{{
         if ok then
             onSuccess(json)
         else -- try again
-            hs.timer.doAfter(1, function() self:getWinStackIdxs() end)
+            hs.timer.doAfter(1, function() self:getWinStackIdxs(onSuccess) end)
         end
     end, {c.paths.getStackIdxs, c.paths.yabai, c.paths.jq}):start()
 end -- }}}


### PR DESCRIPTION
I noticed an exception on this line and I think the previous behavior was a bug.

I'm not very familiar with lua so please feel free to correct if there's something wrong here.