### PR TITLE
Refactor/deprecate ipc msgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Did the terminal window expand to cover the area previously occupied by Safari? 
 If the icons are a bit too heavy for you, you can toggle minimalist mode by turning the icons off:
 
 ```sh
- echo ":toggle_appearance.show_icons:" | hs -m stackline-config
+hs -c 'stackline.config:toggle("appearance.showIcons")'
 ```
 
 

--- a/stackline/configmanager.lua
+++ b/stackline/configmanager.lua
@@ -232,8 +232,10 @@ function M:set(path, val) -- {{{
 end -- }}}
 
 function M:toggle(key) -- {{{
-    local toggledVal = not self:get(key)
-    log.d('Toggling', key, 'from ', self:get(key), 'to ', toggledVal)
+    local val = self:get(key)
+    if type(val)~='boolean' then log.w(key, 'cannot be toggled because it is not boolean') end
+    local toggledVal = not val
+    log.d('Toggling', key, 'from ', val, 'to ', toggledVal)
     self:set(key, toggledVal)
     return self
 end -- }}}

--- a/stackline/configmanager.lua
+++ b/stackline/configmanager.lua
@@ -157,7 +157,7 @@ function M:validate(conf) -- {{{
         log.e('Invalid stackline config:\n', hs.inspect(err))
     end
 
-    return valid, err
+    return isValid, err
 end -- }}}
 
 function M:autosuggest(path) -- {{{


### PR DESCRIPTION
Deprecates support for controlling stackline via ipc messages in favor of the `hs` cli:

*Before*

```sh
echo ":appearance.radius:3 | hs -m stackline-config
```

*After*

```sh
hs -c "stackline.config:set('appearance.radius', 3)"
```



