### PR TITLE
Accepts custom Hammerspoon config dirs in helper

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
--- Simplify requiring stackline from ~/hammerspoon/init.lua
+-- Simplify requiring stackline from hammerspoon init.lua
 
-package.path = os.getenv'HOME' ..'/.hammerspoon/stackline/?.lua;' .. package.path
+package.path = hs.configdir ..'/stackline/?.lua;' .. package.path
 return require 'stackline.stackline'


### PR DESCRIPTION
This removes the hardcoded Hammerspoon config path from the `init.lua` helper and replaces it with `hs.configdir`.

I have been using this small modification to the `init.lua` helper for the last hour. It works well with my custom config directory and thus fixes https://github.com/AdamWagner/stackline/issues/96. From what I can tell, it should not interfere with anything else.

Just wanted to give back something. This is my first contact with Lua, Hammerspoon and Stackline, so feel free to comment/modify/reject. Cheers!