### PR TITLE
Better error message if calling yabai failed

### DIFF
--- a/stackline/query.lua
+++ b/stackline/query.lua
@@ -5,12 +5,19 @@ local function yabai(command, callback) -- {{{
     callback = callback or function(x) return x end
     command = '-m ' .. command
 
-    hs.task.new(
-        stackline.config:get'paths.yabai',
-        u.task_cb(callback),   -- wrap callback in json decoder
-        command:split(' ')
+    local task = hs.task.new(
+      stackline.config:get 'paths.yabai',
+      u.task_cb(callback),     -- wrap callback in json decoder
+      command:split(' ')
     ):start()
-end  -- }}}
+    if not task then
+      log.e(
+        "Error calling '" ..
+        stackline.config:get('paths.yabai') ..
+        " " .. command .. "'. " .. "Please check logs above this message to find out what went wrong."
+      )
+    end
+  end                                       -- }}}
 
 local function stackIdMapper(yabaiWindow) -- {{{
     -- u.p(yabaiWindow)


### PR DESCRIPTION
Used to just print:
```
** Warning:   LuaSkin: hs.task:launch() Unable to launch hs.task process: launch path not accessible
```

Now it prints the full command it was trying to run in addition:

```
query: Error calling '/usr/local/bin/yabai -m query --windows'. Please check logs above this message to find out what went wrong.
```

This is useful because the default path for yabai is wrong on Apple Silicone Macs using homebrew, which now installs packages into `/opt/homebrew/`